### PR TITLE
Add option to set frequency and amplitude directly

### DIFF
--- a/pysinewave/sinewave.py
+++ b/pysinewave/sinewave.py
@@ -11,8 +11,8 @@ class SineWave:
         and amplitude (volume).'''
 
     def __init__(self, 
-                 pitch=0, pitch_per_second=12, 
-                 decibels=0, decibels_per_second=1, 
+                 pitch=None, pitch_per_second=12, 
+                 decibels=None, decibels_per_second=1, 
                  frequency=None, amplitude=None,
                  channels=1, channel_side="lr",
                  samplerate=utilities.DEFAULT_SAMPLE_RATE):

--- a/pysinewave/sinewave.py
+++ b/pysinewave/sinewave.py
@@ -10,13 +10,19 @@ class SineWave:
     '''Generates and plays a continuous sinewave, with smooth transitions in frequency (pitch)
         and amplitude (volume).'''
 
-    def __init__(self, pitch=0, pitch_per_second=12, decibels=0, decibels_per_second=1, channels=1, channel_side="lr",
-                samplerate=utilities.DEFAULT_SAMPLE_RATE):
-
+    def __init__(self, 
+                 pitch=0, pitch_per_second=12, 
+                 decibels=0, decibels_per_second=1, 
+                 frequency=None, amplitude=None,
+                 channels=1, channel_side="lr",
+                 samplerate=utilities.DEFAULT_SAMPLE_RATE):
+        
         self.sinewave_generator = sinewave_generator.SineWaveGenerator(
-                                    pitch=pitch, pitch_per_second=pitch_per_second,
-                                    decibels = decibels, decibels_per_second=decibels_per_second,
-                                    samplerate=samplerate)
+            pitch=pitch, pitch_per_second=pitch_per_second,
+            decibels = decibels, decibels_per_second=decibels_per_second,
+            frequency=frequency, amplitude=amplitude,
+            samplerate=samplerate,
+        )
 
         # Create the output stream
         self.output_stream = sd.OutputStream(channels=channels, callback= lambda *args: self._callback(*args), 
@@ -45,8 +51,6 @@ class SineWave:
             outdata[:, self.channel_side] = 0.0
             
 
-
-
     def play(self):
         '''Plays the sinewave (in a separate thread). Changes in frequency or amplitude will transition smoothly.'''
         self.output_stream.start()
@@ -63,7 +67,12 @@ class SineWave:
         '''Sets the goal pitch of the sinewave (relative to middle C), 
         which will be smoothly transitioned to.'''
         self.sinewave_generator.set_pitch(pitch)
-    
+
+    def set_amplitude(self, amplitude):
+        '''Sets the goal amplitude of the sinewave, which will be smoothly transitioned to.'''
+        self.sinewave_generator.set_amplitude(amplitude)
+
     def set_volume(self, volume):
         '''Sets the goal volume (in decibels, relative to medium volume) of the sinewave'''
         self.sinewave_generator.set_decibels(volume)
+        

--- a/pysinewave/sinewave_generator.py
+++ b/pysinewave/sinewave_generator.py
@@ -2,6 +2,10 @@ import numpy as np
 
 from pysinewave import utilities
 
+DEFAULT_PITCH = 0
+DEFAULT_DECIBELS = 0
+
+
 class SineWaveGenerator:
     '''Generates continuous sine wave data that smoothly transitions between pitches and volumes. 
     (For simplicity, use SineWave instead. 
@@ -9,24 +13,30 @@ class SineWaveGenerator:
 
     def __init__(self, 
                  pitch, pitch_per_second=12, 
-                 decibels=1, decibels_per_second=1, 
+                 decibels=None, decibels_per_second=1, 
                  frequency=None, amplitude=None,
                  samplerate=utilities.DEFAULT_SAMPLE_RATE):
         
-        if frequency is None:
+        if pitch is None:
+            if frequency is None:
+                self.frequency = utilities.pitch_to_frequency(DEFAULT_PITCH)
+            else:
+                self.frequency = frequency
+        else:
             self.frequency = utilities.pitch_to_frequency(pitch)
-        else:
-            if pitch is not None:
-                print('Warning: Both pitch and frequency were given. Using frequency.')
-            self.frequency = frequency
+            if frequency is not None:
+                print('Warning: Both pitch and frequency were given. Using pitch.')
         
-        if amplitude is None:
+        if decibels is None:
+            if amplitude is None:
+                self.amplitude = utilities.decibels_to_amplitude_ratio(DEFAULT_DECIBELS)
+            else:
+                self.amplitude = amplitude
+        else:
             self.amplitude = utilities.decibels_to_amplitude_ratio(decibels)
-        else:
-            if decibels is not None:
-                print('Warning: Both decibels and amplitude were given. Using amplitude.')
-            self.amplitude = amplitude
-        
+            if amplitude is not None:
+                print('Warning: Both decibels and amplitude were given. Using decibels.')
+
         self.phase = 0
 
         self.pitch_per_second = pitch_per_second

--- a/pysinewave/sinewave_generator.py
+++ b/pysinewave/sinewave_generator.py
@@ -7,11 +7,27 @@ class SineWaveGenerator:
     (For simplicity, use SineWave instead. 
     SineWaveGenerator is included to allow for alternative uses of generated sinewave data.)'''
 
-    def __init__(self, pitch, pitch_per_second=12, decibels=1, decibels_per_second=1, 
-                samplerate=utilities.DEFAULT_SAMPLE_RATE):
-        self.frequency = utilities.pitch_to_frequency(pitch)
+    def __init__(self, 
+                 pitch, pitch_per_second=12, 
+                 decibels=1, decibels_per_second=1, 
+                 frequency=None, amplitude=None,
+                 samplerate=utilities.DEFAULT_SAMPLE_RATE):
+        
+        if frequency is None:
+            self.frequency = utilities.pitch_to_frequency(pitch)
+        else:
+            if pitch is not None:
+                print('Warning: Both pitch and frequency were given. Using frequency.')
+            self.frequency = frequency
+        
+        if amplitude is None:
+            self.amplitude = utilities.decibels_to_amplitude_ratio(decibels)
+        else:
+            if decibels is not None:
+                print('Warning: Both decibels and amplitude were given. Using amplitude.')
+            self.amplitude = amplitude
+        
         self.phase = 0
-        self.amplitude = utilities.decibels_to_amplitude_ratio(decibels)
 
         self.pitch_per_second = pitch_per_second
         self.decibels_per_second = decibels_per_second


### PR DESCRIPTION
For Fourier synthesis, it is quite useful to have the ability to set frequencies and amplitudes directly, instead of changing them after the instancing. Also, the method set_amplitude of the class SineWave as described in README, was added.